### PR TITLE
User-Agent added at Headers

### DIFF
--- a/4redirect.py
+++ b/4redirect.py
@@ -7,7 +7,7 @@ y = '\033[033m'
 b = '\033[036m'
 n = '\033[00m'
 cookies = {} 
-headers = {}
+headers = {"User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36"}
 vuln_vitims = {}
 def main():
     path = input(f"[ {y}TARGET{n} ] Websites list file path. default[sites.txt]: ")

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This is the open redirect scanner using Python. If any bug or error please conta
 # Usage
 default files
 
-payloads.txt for payloads list
+**payloads.txt** : for payloads list
 
-sites.txt for targets website list
+**sites.txt** : for targets website list
 
 ```
 root@kali:~# python3 4redirect.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 This is the open redirect scanner using Python. If any bug or error please contact me. Thank u!❤️
 
+# Usage
+default files
+
+payloads.txt for payloads list
+
+sites.txt for targets website list
+
+```
+root@kali:~# python3 4redirect.py
+
+
+  ____ ___         ___             __ 
+ / / // _ \___ ___/ (_)______ ____/ /_
+/_  _/ , _/ -_) _  / / __/ -_) __/ __/
+ /_//_/|_|\__/\_,_/_/_/  \__/\__/\__/
+
+  MSF: http://www.mmsecurity.net/forum/member.php?action=register&referrer=9450
+		                 		v1.0 
+    
+[ TARGET ] Websites list file path. default[sites.txt]: 
+[ SYMBOLS ] Special character. default[!!]: 
+[ PAYLOAD ] Payload list path. default[payloads.txt]: 
+------------------------------------------------------------
+[ SCAN ] Scanning the target(s)...
+
+[ VULNERABLE ] http://localhost/redirect.php?url=http://www.google.com <302>
+[ VULNERABLE ] http://localhost/redirect2.php?url=http://www.google.com <302>
+[ VULNERABLE ] http://localhost/redirect3.php?url=http://www.google.com <302>
+
+[ SUCCESS ] Success rate: 100.00%
+
+```
+
 # Disclaimer
 
 Author will not responsible for any misuses and unauthorized action. Use at your own risk.


### PR DESCRIPTION
By Adding valid user-agent at the request, this could bypass a some WAF.
by default, The requests lib used the default useragent string "**python-requests/2.23.0**"

`
GET / HTTP/1.1
Host: localhost
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.23.0

`